### PR TITLE
Feat: Member 기초 구현 (DAME-10)

### DIFF
--- a/src/main/java/com/diarymate/dame/member/controller/MemberController.java
+++ b/src/main/java/com/diarymate/dame/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.diarymate.dame.member.controller;
+
+import com.diarymate.dame.common.response.BaseResponse;
+import com.diarymate.dame.member.entity.Member;
+import com.diarymate.dame.member.service.MemberService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+
+
+  @GetMapping("")
+  public BaseResponse<List<Member>> getMemberList(Pageable pageable) {
+    List<Member> members = memberService.getMemberList(pageable);
+    return new BaseResponse<>(members);
+  }
+}

--- a/src/main/java/com/diarymate/dame/member/entity/Member.java
+++ b/src/main/java/com/diarymate/dame/member/entity/Member.java
@@ -1,0 +1,85 @@
+package com.diarymate.dame.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member implements UserDetails {
+
+  @Id
+  @Column(name = "member_id")
+//  @GeneratedValue(strategy = GenerationType.IDENTITY) // 지금은 kakao_id로 특정을 하고 있어 AutoIncrease 사용 안함
+  private Long id;
+  @Column(name = "username")
+  private String username;
+  @Column(name = "email")
+  private String email;
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  public static Member of(OAuth2User oAuth2User) {
+    Map<String, Object> attributes = oAuth2User.getAttributes();
+    return Member.builder()
+        .id((long) attributes.get("id"))
+        .email((String)attributes.get("email"))
+        .username((String)attributes.get("username"))
+        .build();
+  }
+
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.singletonList(new SimpleGrantedAuthority(role.name()));
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return false;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+
+  public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+  }
+}

--- a/src/main/java/com/diarymate/dame/member/repository/MemberRepository.java
+++ b/src/main/java/com/diarymate/dame/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.diarymate.dame.member.repository;
+
+import com.diarymate.dame.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+  Member findByUsername(String username);
+
+  Member findByEmail(String email);
+
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/com/diarymate/dame/member/service/MemberService.java
+++ b/src/main/java/com/diarymate/dame/member/service/MemberService.java
@@ -1,0 +1,45 @@
+package com.diarymate.dame.member.service;
+
+import com.diarymate.dame.member.entity.Member;
+import com.diarymate.dame.member.entity.Member.Role;
+import com.diarymate.dame.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+
+  public List<Member> getMemberList(Pageable pageable) {
+    return memberRepository.findAll(pageable)
+        .stream()
+        .collect(Collectors.toList());
+  }
+
+  public Member findMemberByEmail(String email) {
+    return memberRepository.findByEmail(email);
+  }
+
+  public Optional<Member> findMemberById(Long id) {
+    return memberRepository.findById(id);
+  }
+
+  public void registerMember(Member requestMember) {
+    if(memberRepository.existsById(requestMember.getId())){
+      return;
+    }
+    Member newMember = Member.builder()
+        .id(requestMember.getId())
+        .username(requestMember.getUsername())
+        .email(requestMember.getEmail())
+        .role(Role.ROLE_USER)
+        .build();
+    memberRepository.save(newMember);
+  }
+}


### PR DESCRIPTION
## 개요
- 다른 작업에 앞서 `Member` 기초 구현

## 작업사항
- `Member`에 대한 `Repository`, `Entity`, `Controller`, `Service` 추가

## 변경로직
- `{baseURL}/members`에 멤버 전체 조회 추가
